### PR TITLE
Add the materialized views

### DIFF
--- a/table/table_bloat.sql
+++ b/table/table_bloat.sql
@@ -1,4 +1,4 @@
-/* WARNING: executed with a non-superuser role, the query inspect only tables you are granted to read.
+/* WARNING: executed with a non-superuser role, the query inspect only tables and materialized view (9.3+) you are granted to read.
 * This query is compatible with PostgreSQL 9.0 and more
 */
 SELECT current_database(), schemaname, tblname, bs*tblpages AS real_size,
@@ -52,7 +52,7 @@ FROM (
           AND s.tablename = tbl.relname AND s.inherited=false AND s.attname=att.attname
         LEFT JOIN pg_class AS toast ON tbl.reltoastrelid = toast.oid
       WHERE NOT att.attisdropped
-        AND tbl.relkind = 'r'
+        AND tbl.relkind in ('r','m')
       GROUP BY 1,2,3,4,5,6,7,8,9,10
       ORDER BY 2,3
     ) AS s


### PR DESCRIPTION
Hello,

Since the introduction of refresh concurrently (9.4+) mode on materialized views (9.3), these objects can become bloated.
The following PR, perhaps a little too simplistic, but normally functional, adds the materialized views as part of the measurement of bloated.
The name of the columns in the query 'table_bloat.sql' remains unchanged. There is no particular code which would be specific to versions 9.4 and higher, which are the only versions to be potentially affected by bloated materialized views.
